### PR TITLE
Remove legacy retrieval contracts and fail closed on benchmark drift

### DIFF
--- a/ARCH.md
+++ b/ARCH.md
@@ -63,7 +63,7 @@ Decision text for the current draft:
 - Keep `geoIR audit` as the primary CLI command for geometric interpretability over local corpora.
 - Treat `geoIR audit --plot` as experimental until `AuditResult` carries graph data and the plotting path is documented and tested.
 - Remove `geoIR report-save` from the public CLI surface.
-- Keep `geoIR search` only as a deprecated and unsupported compatibility stub until the next clean CLI cut.
+- Remove `geoIR search` from the public CLI surface.
 - Remove `geoIR eval` from the public CLI surface.
 
 This shrink is intentional. The CLI is being optimized for geometric inspection and local debugging, not for general retrieval serving, benchmark orchestration, or LLM-judge workflows.
@@ -75,7 +75,7 @@ This matrix covers the flows that should be validated with the team first.
 | Flow | Intended audience | Initial status | Why it is classified this way | Candidate acceptance check |
 | --- | --- | --- | --- | --- |
 | `import geoIR` | library consumers | Experimental | The package now lazy-registers the retrieval backend so plain `import geoIR` no longer pulls the optional HuggingFace stack at import time. The flow remains experimental until the team decides whether no-extra package import is part of the supported contract and adds an explicit smoke test. | In a clean environment without the `hf` extra, verify `python -c "import geoIR"` succeeds. |
-| `geoIR search` | CLI users | Deprecated / unsupported | The command remains temporarily visible for compatibility, but now fails fast by design. The underlying defects still exist: `geoIR.data` exposes no `load` entry point, and `Index.search` expects `query_emb: np.ndarray` while the old CLI passed a raw `str`. The command is pending removal in a future clean CLI cut. | Keep a smoke test that verifies the deprecated command exits with a clear unsupported message and code `2`. |
+| `geoIR search` | CLI users | Removed from CLI v0 | The historical command was not executable against the current loader and index contracts, so it is no longer registered. | Keep it absent from CLI help unless a future implementation defines and tests a new supported contract. |
 | `geoIR eval` | CLI users | Removed from CLI v0 | The historical command was removed from the public CLI surface. Its previous implementation called `_SUD(obj["gt_docs"], obj["new_docs"], reference=obj["reference"])`, which did not match `SUD(query, gt_docs, new_docs, *, judges=None, policy="mean")`. | Keep it absent from CLI help until or unless a future CLI surface reintroduces a supported evaluation workflow. |
 | `quick_experiment` | library/demo users | Experimental | The public docstring in `geoIR/__init__.py` suggests `beir/fiqa` style datasets, but the implementation passes `dataset` to `load_corpus(str(corpus_path))`, which treats it as a local plain-text file path. The triplet construction (`negatives = corpus[1:] + corpus[:1]`) is a synthetic rotation, not a real triplet-mining step. | Decide whether this helper is local-demo only or a real benchmark entry point; then test against a tiny fixture and align the docstring with the actual behavior. |
 | `training` (classic) | model developers | Unsupported | `_train_classic` calls `self.encoder.q_model.fit(...)`, but `encoder.q_model` is built via `AutoModel.from_pretrained(model_name)` in `geoIR/retrieval/encoder.py`. `AutoModel` does not expose a `.fit(train_objectives=...)` API; only `sentence_transformers.SentenceTransformer` does. The classic path cannot execute as written. | Either wrap the encoder so its `q_model` is a `SentenceTransformer`, or rewrite `_train_classic` against the HF Trainer / a plain PyTorch loop. Add one regression test covering the chosen contract. |
@@ -211,7 +211,7 @@ Current state does not yet meet that bar.
 ## Questions To Validate With The Team
 
 1. Do we want `import geoIR` without the `hf` extra to be part of the supported contract? This PR makes that possible via lazy retrieval backend registration, but it is not yet declared stable.
-2. Does the team accept the proposed CLI v0 scope: keep `encode` and `audit`, keep `audit --plot` experimental, keep `search` deprecated/unsupported until the next clean cut, and remove `eval` plus `report-save` from the public CLI surface?
+2. The accepted CLI v0 scope keeps `encode` and `audit`, keeps `audit --plot` experimental, and removes `search`, `eval`, and `report-save` from the public CLI surface.
 3. Is `quick_experiment` a demo helper or a maintained benchmark entry point? The current docstring and implementation disagree.
 4. Is training in scope for the near-term public API, or only for internal research? Both classic and geometric paths fail to execute today; neither can be promoted without non-trivial work.
 5. Should `research/` remain intentionally non-portable, or should it become reproducible from a clean checkout?

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync verify-cpu format format-check lint types type test check pre-commit build clean summary
+.PHONY: help sync verify-cpu format format-check lint types test check pre-commit build clean summary
 
 .DEFAULT_GOAL := help
 
@@ -28,9 +28,6 @@ lint: sync
 
 types: sync
 	$(RUN) mypy geoIR
-
-type: types
-
 test: sync
 	$(RUN) pytest tests -q
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,8 @@ The supported CLI v0 focus is geometric interpretability and local debugging:
 - `geoIR encode`: encode local texts and optionally save `.npy` embeddings.
 - `geoIR audit`: inspect geometric properties of an index built from a local corpus.
 
-The deprecated/unsupported transitional command is:
-
-- `geoIR search`
-
 Notes:
 
-- `geoIR search` is intentionally fail-fast in CLI v0 and pending removal in a future clean CLI cut.
 - `geoIR audit --plot` is experimental and not part of the supported contract yet.
 - For the current architecture and support boundary, see `ARCH.md`.
 
@@ -149,7 +144,7 @@ This repository includes a `Makefile` with the following commands:
 - `make format`: Format the maintained Python sources.
 - `make format-check`: Check formatting without rewriting files.
 - `make lint`: Run Ruff without rewriting files.
-- `make types`: Run the type checker (`make type` remains an alias).
+- `make types`: Run the type checker.
 - `make test`: Run the offline unit tests.
 - `make check`: Verify the CPU backend and run the complete default gate.
 - `make pre-commit`: Run all repository hooks.

--- a/geoIR/cli.py
+++ b/geoIR/cli.py
@@ -39,28 +39,6 @@ def encode(
         typer.echo(f"Saved to {output}")
 
 
-@app.command(deprecated=True)
-def search(
-    model: Annotated[str, typer.Argument(help="Model checkpoint")],
-    corpus: Annotated[
-        str,
-        typer.Argument(
-            help="Dataset spec, e.g. 'file:~/docs/*.txt' or 'beir/fiqa' or path to .txt"
-        ),
-    ],
-    k: Annotated[int, typer.Option(help="Neighbors for k-NN index")] = 30,
-    query: Annotated[str, typer.Option(help="Query to search")] = "",
-    top: Annotated[int, typer.Option(help="Returned docs")] = 10,
-):
-    """Deprecated search command kept temporarily for CLI compatibility."""
-    typer.echo(
-        "geoIR search is deprecated and not supported in CLI v0. "
-        "It will be removed in a future clean CLI cut.",
-        err=True,
-    )
-    raise typer.Exit(code=2)
-
-
 @app.command()
 def audit(
     model: Annotated[str, typer.Argument(help="Model checkpoint")],
@@ -87,10 +65,6 @@ def audit(
     if plot:
         audit_res.plot("tsne")
 
-
-# Alias for backward compatibility: Click entry point expected a `cli` callable.
-# We expose it so old `python -m geoIR.cli` still works.
-cli = app
 
 if __name__ == "__main__":  # pragma: no cover
     app()

--- a/geoIR/retrieval/index.py
+++ b/geoIR/retrieval/index.py
@@ -130,7 +130,6 @@ class Index:  # noqa: D101
         metric: str = "cosine",
         search_k: int = 1000,
         connect_k: int = 10,
-        mix_kappa: float | None = None,
         alpha: float | None = None,
     ) -> list[int]:  # noqa: D401
         """Search using cosine or cosine+κ(x) mix.
@@ -139,31 +138,27 @@ class Index:  # noqa: D101
         ----------
         query_emb : np.ndarray
             A pre-computed query embedding of shape `(d,)`.
-        mix_kappa : float | None, optional
-            Curvature weight (legacy, prefer `alpha`).
         alpha : float | None, optional
             Mixing factor [0, 1] for cosine vs curvature (0 = pure cosine, 1 = pure curvature).
-            If both `alpha` and `mix_kappa` are provided, `alpha` takes precedence.
         """
 
         metric = metric.lower()
 
         # ------------------------------------------------------------------
-        # 2. Fast path – cosine / curvature-mix (legacy)
+        # 2. Fast path – cosine / curvature mix
         # ------------------------------------------------------------------
         if metric in {"cosine", "curvature", "mix"}:
             sims = (self.embeddings @ query_emb).flatten()
-            mix_kappa_val: float | None
+            curvature_weight: float | None
 
-            # Support both alpha (preferred) and mix_kappa (legacy)
             if alpha is not None:
                 if not 0 <= alpha <= 1:
                     raise ValueError(f"alpha must be between 0 and 1, got {alpha}")
-                mix_kappa_val = alpha / (1 - alpha) if alpha < 1.0 else float("inf")
+                curvature_weight = alpha / (1 - alpha) if alpha < 1.0 else float("inf")
             else:
-                mix_kappa_val = mix_kappa
+                curvature_weight = None
 
-            if mix_kappa_val is not None:
+            if curvature_weight is not None:
                 # compute average curvature per node lazily once
                 if not hasattr(self, "_avg_curv"):
                     from collections import defaultdict
@@ -179,7 +174,7 @@ class Index:  # noqa: D101
                 if alpha is not None and alpha < 1.0:
                     sims = (1 - alpha) * sims + alpha * curv_vals
                 else:
-                    sims = sims + mix_kappa_val * curv_vals
+                    sims = sims + curvature_weight * curv_vals
             return np.argsort(sims)[-k:][::-1].tolist()
 
         # ------------------------------------------------------------------

--- a/research/BEIR_BENCHMARK_SPEC.md
+++ b/research/BEIR_BENCHMARK_SPEC.md
@@ -193,7 +193,7 @@ respaldados sin un run v2 reproducible.
 
 - Solo cuentan como backed claims los resultados que aparecen en artefactos v2
   válidos.
-- Los runs legacy quedan fuera del agregado hasta rerun real.
+- Los runs de otro esquema hacen fallar el agregado y requieren un rerun real.
 - `SUMMARY.md` y `summary.csv` deben poder regenerarse sin edición manual.
 - Si un claim aparece en notas históricas pero no en artefactos respaldados,
   debe tratarse como no confiable.

--- a/research/TESTING_PLAN.md
+++ b/research/TESTING_PLAN.md
@@ -30,7 +30,7 @@ No define APIs públicas; define contratos verificables y backlog de cobertura.
 2. Contract tests de artefactos.
    - cada run válido genera `config.json`, `beir_results.json`, `beir_results.csv`, `run.log`
    - `summary.csv` y `SUMMARY.md` se regeneran desde artefactos respaldados
-   - runs legacy o incompletos se excluyen
+   - runs de otro esquema o incompletos hacen fallar el agregado
 
 3. Integration tests offline.
    - fixture BEIR mínimo local
@@ -65,7 +65,7 @@ No define APIs públicas; define contratos verificables y backlog de cobertura.
 - Cache key estable.
 - Run end-to-end offline con artefactos completos.
 - Contrato de `rerank=none` y `rerank=ppr`.
-- Exclusión de runs legacy del summary.
+- Rechazo de runs de otro esquema en el summary.
 - Decisión gate para `soft_local` y `soft_ppr`.
 - Matriz fija del runner.
 

--- a/research/beir_euclidean_vs_geo.py
+++ b/research/beir_euclidean_vs_geo.py
@@ -1137,8 +1137,8 @@ def render_summary_markdown(summary_df: pd.DataFrame, invalid_runs: list[str]) -
         "",
         "This file is generated only from `config.json` + `beir_results.json` artifacts.",
         (
-            f"It only accepts benchmark schema v{BENCHMARK_SCHEMA_VERSION}; "
-            "legacy result rows are skipped."
+            f"It accepts only benchmark schema v{BENCHMARK_SCHEMA_VERSION}; "
+            "any other or invalid run fails summary generation."
         ),
         (
             "Historical manual notes elsewhere in the repo are non-authoritative "
@@ -1186,6 +1186,9 @@ def write_summary_artifacts(experiment_dir: Path) -> tuple[Path, Path]:
     experiment_root = experiment_dir.expanduser().resolve()
     experiment_root.mkdir(parents=True, exist_ok=True)
     summary_df, invalid_runs = build_summary_df(experiment_root)
+    if invalid_runs:
+        joined = ", ".join(invalid_runs)
+        raise ValueError(f"Unsupported or invalid benchmark runs: {joined}")
 
     summary_csv = experiment_root / "summary.csv"
     summary_md = experiment_root / "SUMMARY.md"

--- a/research/results/beir_euclidean_vs_geo/README.md
+++ b/research/results/beir_euclidean_vs_geo/README.md
@@ -13,7 +13,7 @@ Regla operativa:
 
 - No mantener tablas manuales en este `README.md`.
 - No sacar conclusiones desde notas históricas si no están respaldadas por un par `config.json` + `beir_results.json`.
-- El agregado acepta solo el esquema de benchmark actual; los runs legacy quedan fuera hasta rerun real.
+- El agregado acepta solo el esquema de benchmark actual; los runs de otro esquema hacen fallar la generación hasta un rerun real.
 - Los claims manuales previos sobre `msmarco-passage` quedan no confiables hasta que exista un rerun respaldado por artefactos.
 
 Para regenerar el resumen agregado sin editar archivos a mano, vuelve a ejecutar

--- a/research/results/beir_euclidean_vs_geo/SUMMARY.md
+++ b/research/results/beir_euclidean_vs_geo/SUMMARY.md
@@ -1,7 +1,7 @@
 # BEIR Benchmark Summary
 
 This file is generated only from `config.json` + `beir_results.json` artifacts.
-It only accepts benchmark schema v2; legacy result rows are skipped.
+It only accepts benchmark schema v2; other schema versions fail summary generation.
 Historical manual notes elsewhere in the repo are non-authoritative and intentionally excluded here.
 That includes the previous `msmarco-passage` claims, which are ignored until a backed run exists.
 Hard-graph ranking is currently explicit as absent; the supported comparison is dense cosine baseline vs one candidate path.

--- a/tests/test_beir_benchmark.py
+++ b/tests/test_beir_benchmark.py
@@ -245,7 +245,7 @@ def write_v2_run_artifacts(
     (run_dir / "beir_results.json").write_text(json.dumps(results, indent=2), encoding="utf-8")
 
 
-def write_legacy_run_artifacts(root: Path, run_id: str) -> None:
+def write_v1_run_artifacts(root: Path, run_id: str) -> None:
     run_dir = root / run_id
     run_dir.mkdir(parents=True)
     config = {"dataset": "fiqa", "max_docs": 1000, "rerank": "none"}
@@ -633,7 +633,7 @@ def test_rerank_ppr_uses_ppr_path_only(tmp_path: Path) -> None:
     assert candidate["path_kind"] == "soft_ppr"
 
 
-def test_summary_skips_legacy_runs_and_uses_only_v2_artifacts(tmp_path: Path) -> None:
+def test_summary_rejects_previous_schema_runs(tmp_path: Path) -> None:
     module = load_benchmark_module()
     experiment_root = tmp_path / "beir_euclidean_vs_geo"
     write_v2_run_artifacts(
@@ -644,24 +644,13 @@ def test_summary_skips_legacy_runs_and_uses_only_v2_artifacts(tmp_path: Path) ->
         rerank="none",
         ppr_topk=100,
     )
-    write_legacy_run_artifacts(experiment_root, "2025-07-20_23-40-45")
+    write_v1_run_artifacts(experiment_root, "2025-07-20_23-40-45")
 
-    summary_csv, summary_md = module.write_summary_artifacts(experiment_root)
+    with pytest.raises(ValueError, match="Unsupported or invalid benchmark runs"):
+        module.write_summary_artifacts(experiment_root)
 
-    summary_df = pd.read_csv(summary_csv)
-    assert len(summary_df) == 1
-    assert summary_df.iloc[0]["dataset"] == "fiqa"
-    assert summary_df.iloc[0]["baseline_method"] == "Dense cosine baseline"
-    assert summary_df.iloc[0]["candidate_method"] == "Soft graph local"
-    assert "candidate_peak_rss_mb" in summary_df.columns
-    assert "candidate_neighbor_purity_at_k" in summary_df.columns
-    assert "candidate_edge_overlap_with_dense_at_k" in summary_df.columns
-
-    summary_text = summary_md.read_text(encoding="utf-8")
-    assert "schema v2" in summary_text
-    assert "Cand RSS MB" in summary_text
-    assert "Skipped Runs" in summary_text
-    assert "2025-07-20_23-40-45" in summary_text
+    assert not (experiment_root / "summary.csv").exists()
+    assert not (experiment_root / "SUMMARY.md").exists()
 
 
 def test_render_decision_gate_for_soft_local_and_ppr() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,33 +13,16 @@ def plain_output(output: str) -> str:
     return ANSI_RE.sub("", output)
 
 
-def test_top_level_help_lists_supported_and_transitional_commands() -> None:
+def test_top_level_help_lists_only_supported_commands() -> None:
     result = runner.invoke(app, ["--help"])
     output = plain_output(result.output)
 
     assert result.exit_code == 0
     assert "encode" in output
     assert "audit" in output
-    assert "search" in output
+    assert "search" not in output
     assert "eval" not in output
     assert "report-save" not in output
-
-
-def test_search_help_marks_command_as_deprecated() -> None:
-    result = runner.invoke(app, ["search", "--help"])
-    output = plain_output(result.output)
-
-    assert result.exit_code == 0
-    assert "deprecated" in output.lower()
-
-
-def test_search_exits_with_clear_deprecation_message() -> None:
-    result = runner.invoke(app, ["search", "demo-model", "demo-corpus.txt", "--query", "hello"])
-    output = plain_output(result.output)
-
-    assert result.exit_code == 2
-    assert "deprecated" in output.lower()
-    assert "not supported in cli v0" in output.lower()
 
 
 def test_audit_help_marks_plot_as_experimental() -> None:


### PR DESCRIPTION
## Summary
- remove the unsupported `geoIR search` command and compatibility callable
- remove the `make type` and `mix_kappa` aliases
- align the architecture and CLI docs with the reduced supported surface
- reject unsupported or invalid benchmark-schema runs instead of silently skipping them

## Breaking changes
- `geoIR search`, `geoIR.cli.cli`, `make type`, and `Index.search(mix_kappa=...)` are removed
- summary generation now fails when any run is not valid for schema v2

## Validation
- CPU-only backend verified
- Ruff format and lint passed
- mypy passed for 28 source files
- 21 tests passed
- pre-commit `project checks` hook passed